### PR TITLE
feat: allocate pv methods

### DIFF
--- a/docs/deploy/csidriver.yaml
+++ b/docs/deploy/csidriver.yaml
@@ -16,7 +16,7 @@ metadata:
   name: hybrid
 provisioner: csi.hybrid.sinextra.dev
 parameters:
-  storageClasses: proxmox-test,local-path
+  storageClasses: proxmox-test,proxmox,hcloud-volumes,local-path
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete


### PR DESCRIPTION
Two methods to allocate Persistent Volumes (PVs):
* Annotations: This method works with most common CSI plugins.
* Pod: Use this method only if the driver is not based on sig-storage-lib-external-provisioner

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
