### PR TITLE
Fix release pv no wait

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -421,8 +421,29 @@ func (p *HybridProvisioner) bondPVC(ctx context.Context, opts controller.Provisi
 	}
 
 	if storageClass.ReclaimPolicy != nil && *storageClass.ReclaimPolicy == corev1.PersistentVolumeReclaimDelete {
-		patch := []byte(`{"spec":{"persistentVolumeReclaimPolicy":"` + corev1.PersistentVolumeReclaimDelete + `"}}`)
-		if _, err := p.client.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		patch := fmt.Sprintf(
+			`{
+				"spec":
+				{
+					"persistentVolumeReclaimPolicy":"%s",
+					"claimRef":
+					{
+						"apiVersion":"%s",
+						"kind":"%s",
+						"name":"%s",
+						"namespace":"%s",
+						"uid":"%s"
+					}
+				}
+			}`,
+			corev1.PersistentVolumeReclaimDelete,
+			opts.PVC.APIVersion,
+			opts.PVC.Kind,
+			opts.PVC.Name,
+			opts.PVC.Namespace,
+			opts.PVC.UID,
+		)
+		if _, err := p.client.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
 			return fmt.Errorf("failed to patch PersistentVolume: %v", err)
 		}
 	}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -464,10 +464,27 @@ func (p *HybridProvisioner) waitBindPVC(ctx context.Context, pvc *corev1.Persist
 
 func (p *HybridProvisioner) releasePV(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (pv *corev1.PersistentVolume, err error) {
 	var lastSaveError error
+	var newFinalizers []string
+	var patchStr string
 
 	patch := []byte(`{"spec":{"persistentVolumeReclaimPolicy":"` + corev1.PersistentVolumeReclaimRetain + `"}}`)
 	if _, err := p.client.CoreV1().PersistentVolumes().Patch(ctx, pvc.Spec.VolumeName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 		return nil, fmt.Errorf("failed to patch persistentvolume: %v", err)
+	}
+
+	for _, f := range pvc.Finalizers {
+		// Remote kubernetes.io/pvc-protection to avoir PV-controller to rebind PV to Terminating PVC usec for provisioning.
+		if f != "kubernetes.io/pvc-protection" {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+	if len(newFinalizers) > 0 {
+		patchStr = fmt.Sprintf(`{"metadata": {"finalizers": ["%s"]}}`, strings.Join(newFinalizers, `", "`))
+	} else {
+		patchStr = `{"metadata":{"finalizers":null}}`
+	}
+	if _, err := p.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(ctx, pvc.Name, types.MergePatchType, []byte(patchStr), metav1.PatchOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to remove finalizer from persistentvolumeClaim: %v", err)
 	}
 
 	err = wait.ExponentialBackoff(p.backoff, func() (bool, error) {


### PR DESCRIPTION
# Pull Request

As explained in issue #25 there is 2 race conditions on PVC provisioning, which lead in PVC Lost state some times.

This PR implement fix with 2 way exposed without adding delay on provisioning PVC.

- [b853a13](https://github.com/sergelogvinov/hybrid-csi-plugin/commit/b853a132fce92d43576d4794b0b49e17c0057e56) : Remove `kubernetes.io/pvc-protection` on provisioning PVC to avoid PV-controller reconcile this terminating PVC with our freshly provisionned PV which we wanna link to our user created PVC.
- [31ab15c](https://github.com/sergelogvinov/hybrid-csi-plugin/commit/31ab15cb9b4e6294fdc8629a74fc6f0cbe54a8c5) : Refill PV field `.spec.claimlRef` before set Policy from Retain to Delete on our user PVC's, to avoid PV state "Available" and Policy "Delete" and an empty feild `.spec.claimRef` which could lead to a PV deletion by PV-controller.