### PR TITLE
fix: gh-action cleanup

### DIFF
--- a/.github/workflows/build-edge.yaml
+++ b/.github/workflows/build-edge.yaml
@@ -61,5 +61,6 @@ jobs:
         with:
           package-name: hybrid-csi-provisioner
           package-type: container
+          min-versions-to-keep: 10
           delete-only-untagged-versions: 'true'
         continue-on-error: true


### PR DESCRIPTION
Fix actions/delete-package-versions script deletes release images. This issue likely occurs because we sign the images.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
